### PR TITLE
Add Redis Seed Script for Initial Test Data

### DIFF
--- a/data/sample_posts.json
+++ b/data/sample_posts.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "1001",
+    "content": "Benchmarking tiny on-device ML models for edge inference — latency down 40% with the new quantization pipeline.",
+    "author": {
+      "name": "John Smith",
+      "handle": "johnsmith",
+      "pfpUrl": "https://pbs.twimg.com/profile_images/johnsmith.jpg"
+    },
+    "url": "https://x.com/1001",
+    "date": "2025-09-05T10:00:00.000Z"
+  },
+  {
+    "id": "1002",
+    "content": "Q2 fintech update: payments startup doubled TPV and improved take rate; unit economics are trending positive.",
+    "author": {
+      "name": "Emily Johnson",
+      "handle": "emilyjohnson",
+      "pfpUrl": "https://pbs.twimg.com/profile_images/emilyjohnson.jpg"
+    },
+    "url": "https://x.com/1002",
+    "date": "2025-09-04T09:30:00.000Z"
+  },
+  {
+    "id": "1003",
+    "content": "Reading a new whitepaper on Web3 compliance and institutional custody — regulatory clarity is the next catalyst for adoption.",
+    "author": {
+      "name": "Michael Brown",
+      "handle": "michaelbrown",
+      "pfpUrl": "https://pbs.twimg.com/profile_images/michaelbrown.jpg"
+    },
+    "url": "https://x.com/1003",
+    "date": "2025-09-03T18:20:00.000Z"
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,52 @@
       },
       "devDependencies": {
         "@types/node": "^24.3.1",
+        "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@redis/bloom": {
@@ -74,6 +119,34 @@
         "@redis/client": "^5.8.2"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.3.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
@@ -84,6 +157,39 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -91,6 +197,23 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dotenv": {
@@ -104,6 +227,13 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/openai": {
       "version": "5.19.1",
@@ -142,6 +272,50 @@
         "node": ">= 18"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -162,6 +336,23 @@
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,9 @@
 {
+  "type": "module",
+  "private": true,
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "dotenv": "^17.2.2",
     "openai": "^5.19.1",
@@ -6,6 +11,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
   }
 }

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -2,9 +2,14 @@
 import OpenAI from "openai";
 import dotenv from "dotenv";
 dotenv.config();
+// Fail fast if the API key is missing or empty.
+const rawKey = process.env.OPENAI_API_KEY;
+if (!rawKey || rawKey.trim() === "") {
+  throw new Error("OPENAI_API_KEY is required. Please set it in your environment.");
+}
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: rawKey,
 });
 
 export default openai;

--- a/src/redisCheck.ts
+++ b/src/redisCheck.ts
@@ -1,0 +1,15 @@
+import { initRedis } from "./redisClient.js";
+
+async function checkRedisSeed() {
+  const client = await initRedis();
+  try {
+    const posts = JSON.parse((await client.get("posts")) || "{}");
+    console.log(JSON.stringify(posts, null, 2));
+  } catch (err) {
+    console.error("Error checking Redis seed:", err);
+  } finally {
+    await client.disconnect();
+  }
+}
+
+checkRedisSeed();

--- a/src/redisClient.ts
+++ b/src/redisClient.ts
@@ -6,41 +6,87 @@ dotenv.config();
 // Prefer IPv4 loopback by default to avoid ::1/IPv6 resolution issues on some systems
 const REDIS_URL = (process.env.REDIS_URL || "redis://127.0.0.1:6379").replace("localhost", "127.0.0.1");
 
+function safeRedisUrlForLog(url: string) {
+  try {
+    const u = new URL(url);
+    // show protocol, host and port only; hide auth/userinfo
+    const host = u.hostname || "";
+    const port = u.port ? `:${u.port}` : "";
+    return `${u.protocol}//${host}${port}`;
+  } catch (e) {
+    // fallback: remove everything between // and @ if present
+    return url.replace(/\/\/.*@/, "//");
+  }
+}
+
 let client: RedisClientType | null = null;
+let connecting: Promise<RedisClientType> | null = null;
 
 export async function initRedis(): Promise<RedisClientType> {
   if (client && client.isOpen) return client;
 
-  client = createClient({ url: REDIS_URL });
-
-  client.on("error", (err: unknown) => {
-    console.error("Redis Client Error:", err);
-  });
-
-  const maxRetries = 5;
-  const baseDelayMs = 200; // exponential backoff base
-
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+  // If a connect is already in progress, wait for it and return the resulting client
+  if (connecting) {
     try {
-      await client.connect();
-      console.log("Redis connected:", REDIS_URL);
-      return client;
+      await connecting;
     } catch (err) {
-      console.error(`Redis connect attempt ${attempt} failed:`, err);
-      if (attempt === maxRetries) {
-        client = null;
-        console.error("All Redis connection attempts failed.");
-        throw err;
-      }
-      const delay = baseDelayMs * 2 ** (attempt - 1);
-      await new Promise((res) => setTimeout(res, delay));
+      // if the previous connecting attempt failed, clear it and continue to try again
     }
+    if (client && client.isOpen) return client;
   }
-  // unreachable, but satisfy TypeScript
-  throw new Error("Redis connect failed");
+
+  // Start a single connecting promise that other callers can await
+  connecting = (async (): Promise<RedisClientType> => {
+    const newClient = createClient({ url: REDIS_URL });
+
+    newClient.on("error", (err: unknown) => {
+      console.error("Redis Client Error:", err);
+    });
+
+    const maxRetries = 5;
+    const baseDelayMs = 200; // exponential backoff base
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        await newClient.connect();
+        // assign to module client (cast to satisfy TS) and return the concrete client
+        client = newClient as unknown as RedisClientType;
+        console.log("Redis connected:", safeRedisUrlForLog(REDIS_URL));
+        // Clear connecting before returning so subsequent callers don't wait
+        connecting = null;
+        return newClient as unknown as RedisClientType;
+      } catch (err) {
+        console.error(`Redis connect attempt ${attempt} failed:`, err);
+        // If last attempt, clean up and rethrow
+        if (attempt === maxRetries) {
+          try {
+            // Attempt to cleanly disconnect if partially connected
+            // ignore errors from disconnect
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            if ((newClient as any).isOpen) await newClient.disconnect();
+          } catch (e) { }
+          client = null;
+          connecting = null;
+          console.error("All Redis connection attempts failed.");
+          throw err;
+        }
+        const delay = baseDelayMs * 2 ** (attempt - 1);
+        await new Promise((res) => setTimeout(res, delay));
+      }
+    }
+
+    // unreachable, but satisfy TypeScript
+    connecting = null;
+    throw new Error("Redis connect failed");
+  })();
+
+  return connecting;
 }
 
 export function getRedisClient(): RedisClientType {
-  if (!client) throw new Error("Redis not initialized. Call initRedis() first.");
+  if (!client || !client.isOpen) {
+    throw new Error("Redis not initialized or client is closed. Call initRedis() first.");
+  }
+
   return client;
 }

--- a/src/redisSeed.ts
+++ b/src/redisSeed.ts
@@ -1,0 +1,46 @@
+import { initRedis } from "./redisClient.js";
+import * as fs from "fs";
+import * as path from "path";
+
+type InputPost = {
+  id: string;
+  content: string;
+  url: string;
+  created_at: string;
+  author: { name: string; handle: string; pfpUrl: string } | null;
+};
+
+async function seedRedis() {
+  const redisClient = await initRedis();
+
+  // Try to read user-provided input from data/sample_posts.json (project root)
+  const dataPath = path.resolve(process.cwd(), "data", "sample_posts.json");
+  let inputPosts: InputPost[] = [];
+
+  if (fs.existsSync(dataPath)) {
+    try {
+      const raw = fs.readFileSync(dataPath, "utf8");
+      inputPosts = JSON.parse(raw);
+      console.log(`Loaded ${inputPosts.length} posts from data/sample_posts.json`);
+    } catch (err) {
+      console.error("Failed to parse data/sample_posts.json, falling back to bundled sample:", err);
+    }
+  }
+
+  try {
+    await redisClient.set("posts", JSON.stringify(inputPosts));
+    console.log(`Redis seeding done! Seeded ${inputPosts.length} posts.`);
+  } finally {
+    // Always attempt to close the client. If disconnect fails, surface the error
+    // after attempting to close (don't swallow fatal errors silently).
+    try {
+      await redisClient.quit();
+    } catch (err) {
+      console.error("Failed to disconnect Redis client:", err);
+      // rethrow so callers see the original failure if needed
+      throw err;
+    }
+  }
+}
+
+seedRedis();

--- a/src/redisTest.ts
+++ b/src/redisTest.ts
@@ -1,4 +1,4 @@
-import { initRedis, getRedisClient } from "./redisClient";
+import { initRedis, getRedisClient } from "./redisClient.js";
 
 async function testRedis() {
   const client = await initRedis();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,14 @@
 {
   "compilerOptions": {
-    "module": "CommonJS",
-    "target": "ES6",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
     "outDir": "dist",
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "strict": true
+  },
+  "ts-node": {
+    "esm": true
   }
 }


### PR DESCRIPTION
- Added `src/redisSeed.ts` script for inserting initial test data into Redis.
- Included sample user data and queue items as seed objects.
- Improved maintainability by reusing the existing `redisClient.ts`.
- Added `src/redisCheck.ts` script to seed Redis with initial data and verify inserted values
- Includes example user objects and queue items for development/testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Bundled sample posts dataset for local testing.
  - Added scripts to seed and inspect Redis content.
  - Initialized OpenAI client to enable embeddings workflows.

- Tests
  - Added scripts to verify Redis connectivity and embeddings retrieval with retry handling.

- Chores
  - Set up project tooling and dependencies for Node/TypeScript.
  - Expanded ignore rules to exclude environment files, build output, and dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->