### PR TITLE
Add OpenAI validation utility with Zod schema and retry logic; integrate into categorization and sentiment analysis

### DIFF
--- a/src/analyzeSentiment.ts
+++ b/src/analyzeSentiment.ts
@@ -1,6 +1,7 @@
 import type OpenAI from 'openai';
 import openai from './openaiClient';
-import { ChatCompletionMessageParam } from 'openai/resources';
+import { callOpenAIWithValidation } from './openaiValidationUtil.js';
+import { z } from 'zod';
 
 // Sentiment analysis result type  
 export type SentimentResult = {
@@ -8,14 +9,15 @@ export type SentimentResult = {
     sentiment: "BULLISH" | "BEARISH" | "NEUTRAL";
 };
 
+// Zod schema for sentiment validation
+const SentimentSchema = z.object({
+    sentiment: z.enum(["BULLISH", "BEARISH", "NEUTRAL"])
+});
+
 // Analyze multiple posts at once
 export async function analyzeMultiplePosts(posts: string[]): Promise<SentimentResult[]> {
     const results: SentimentResult[] = [];
-    for (const post of posts) {
-        try {
-
-            // System prompt for instructions, user prompt for content
-            const systemPrompt = `You are a sentiment analysis system for crypto-related posts.
+    const systemPrompt = `You are a sentiment analysis system for crypto-related posts.
 Classify the sentiment of posts into one of: BULLISH, BEARISH, NEUTRAL.
 
 Important: Always return the sentiment in uppercase letters exactly like this: BULLISH, BEARISH, NEUTRAL,
@@ -26,58 +28,18 @@ Return only valid JSON in this format:
   "sentiment": "BULLISH"
 }`;
 
-            let lastResponse = "";
-            let attempts = 0;
-            const maxAttempts = 3;
+    for (const post of posts) {
+        try {
+            const validated = await callOpenAIWithValidation({
+                client: openai,
+                systemPrompt,
+                userPrompt: post,
+                schema: SentimentSchema,
+                retryCount: 3
+            });
 
-            while (attempts < maxAttempts) {
-                attempts++;
-
-                const messages: ChatCompletionMessageParam[] = [
-                    { role: "system", content: systemPrompt },
-                    { role: "user", content: post }
-                ];
-
-                // Add feedback about previous failed attempt
-                if (attempts > 1) {
-                    messages.push({
-                        role: "user",
-                        content: `Your previous response was invalid: "${lastResponse}". Please provide only valid JSON with the exact format specified.`
-                    });
-                }
-
-                const response = await openai.chat.completions.create({
-                    model: "gpt-4o-mini",
-                    messages,
-                    response_format: { type: "json_object" },
-                    max_tokens: 100
-                });
-
-                const content = response.choices?.[0]?.message?.content;
-                if (!content) {
-                    lastResponse = "No content returned";
-                    continue;
-                }
-
-                lastResponse = content.trim();
-
-                try {
-                    const parsedAny = JSON.parse(lastResponse) as { sentiment?: string };
-                    const raw = (parsedAny.sentiment ?? '').toString().toUpperCase().trim();
-
-                    if (!["BULLISH", "BEARISH", "NEUTRAL"].includes(raw)) {
-                        lastResponse = `Invalid sentiment: ${parsedAny.sentiment}`;
-                        continue;
-                    }
-
-                    results.push({ post, sentiment: raw as "BULLISH" | "BEARISH" | "NEUTRAL" });
-                    break; // Success, exit retry loop
-                } catch (parseError) {
-                    if (attempts === maxAttempts) {
-                        throw new Error(`Failed to get valid JSON after ${maxAttempts} attempts. Last response: ${lastResponse}`);
-                    }
-                    // Continue to next attempt with feedback
-                }
+            if (validated) {
+                results.push({ post, sentiment: validated.sentiment });
             }
         } catch (e) {
             console.error("Error analyzing post:", post, e);

--- a/src/classifyWithOpenAI.ts
+++ b/src/classifyWithOpenAI.ts
@@ -2,6 +2,7 @@
 import type OpenAI from 'openai';
 import type { ChatCompletionMessageParam } from "openai/resources";
 import openai from './openaiClient.js';
+import { callOpenAIWithValidation } from './openaiValidationUtil.js';
 import { z } from 'zod';
 
 const CATEGORIES = [
@@ -48,19 +49,13 @@ Instructions:
 
 Be strict: return only raw JSON with exactly that shape; no code fences or prose.`;
 
-    // Use the utility function for retries and validation
-    const chatParams = {
-        model: "gpt-4o-mini",
-        messages: [
-            { role: "system", content: systemPrompt } as ChatCompletionMessageParam,
-            { role: "user", content: post } as ChatCompletionMessageParam
-        ],
-        response_format: { type: "json_object" } as const,
-        max_tokens: 200
-    };
-    // Import the utility function
-    const { callOpenAIWithValidation } = await import("./openaiValidationUtil.js");
-    return await callOpenAIWithValidation(usedClient, chatParams, CategorizationSchema, 3);
+    return await callOpenAIWithValidation({
+        client: usedClient,
+        systemPrompt,
+        userPrompt: post,
+        schema: CategorizationSchema,
+        retryCount: 3
+    });
 }
 
 // Named function to run categorization

--- a/src/classifyWithOpenAI.ts
+++ b/src/classifyWithOpenAI.ts
@@ -46,7 +46,7 @@ Instructions:
     "subcategories": ["Yield Farming","Lending Strategies","Risk Management"]
 }
 
-Be strict: do not include any explanatory text, only the JSON above (fenced ${'```json'} blocks are acceptable).`;
+Be strict: return only raw JSON with exactly that shape; no code fences or prose.`;
 
     // Use the utility function for retries and validation
     const chatParams = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,11 @@
+// Small shared utilities
+
+export const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+// Exponential backoff with small jitter to avoid thundering herd
+export const jitteredBackoff = (
+    baseMs: number,
+    attempt: number,
+    jitterMs: number = 100
+): number => baseMs * 2 ** (attempt - 1) + Math.floor(Math.random() * jitterMs);

--- a/src/openaiValidationUtil.ts
+++ b/src/openaiValidationUtil.ts
@@ -1,59 +1,72 @@
 import type OpenAI from 'openai';
+import type { ChatCompletionMessageParam } from "openai/resources";
 import { ZodSchema } from 'zod';
+import { sleep, jitteredBackoff } from './lib/utils.js';
 
 /**
  * Calls OpenAI chat completion API and validates the response with a Zod schema, retrying up to maxAttempts times.
  * Returns the validated result or null if all attempts fail.
  */
-export async function callOpenAIWithValidation<T>(
-    openaiClient: OpenAI,
-    chatParams: Parameters<OpenAI['chat']['completions']['create']>[0],
-    zodSchema: ZodSchema<T>,
-    maxAttempts: number = 3
-): Promise<T | null> {
+export async function callOpenAIWithValidation<T>(params: {
+    client: OpenAI,
+    systemPrompt: string,
+    userPrompt: string,
+    schema: ZodSchema<T>,
+    retryCount?: number
+}): Promise<T | null> {
     let lastError: unknown = null;
     const baseDelayMs = 500;
-    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const maxAttempts = params.retryCount ?? 3;
+
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const messages: ChatCompletionMessageParam[] = [
+            { role: "system", content: params.systemPrompt } as ChatCompletionMessageParam,
+            { role: "user", content: params.userPrompt } as ChatCompletionMessageParam
+        ];
+
+        // Add feedback about previous failed attempt
+        if (attempt > 1 && lastError) {
+            const errorMessage = lastError instanceof Error ? lastError.message : String(lastError);
+            messages.push({
+                role: "user",
+                content: `Your previous response was invalid: "${errorMessage}". Please provide only valid JSON with the exact format specified.`
+            } as ChatCompletionMessageParam);
+        }
+
+        const chatParams = {
+            model: "gpt-4o-mini",
+            messages,
+            response_format: { type: "json_object" } as const,
+            max_tokens: 200
+        };
         try {
-            const response = await openaiClient.chat.completions.create(chatParams);
-            // Handle both streaming and non-streaming responses
+            const response = await params.client.chat.completions.create(chatParams);
             let raw: string | undefined;
             if ('choices' in response && Array.isArray(response.choices)) {
                 const content = response.choices[0]?.message?.content;
                 raw = typeof content === 'string' ? content : undefined;
             }
             if (!raw) throw new Error('No content returned from OpenAI');
-            const parsed = JSON.parse(extractJson(raw));
-            return zodSchema.parse(parsed);
+            const parsed = JSON.parse(raw);
+            return params.schema.parse(parsed);
         } catch (err) {
             lastError = err;
-            // Retry only on transient OpenAI conditions
             const anyErr = err as any;
             const status = anyErr?.status || anyErr?.code || anyErr?.error?.code;
             const type = anyErr?.error?.type || anyErr?.type;
             const isRateLimit = status === 429 || type === 'rate_limit';
             const isServerError = typeof status === 'number' && status >= 500;
             const isQuota = type === 'insufficient_quota';
-            if (isQuota) break; // non-retryable in our flow
+            if (isQuota) break;
             if ((isRateLimit || isServerError) && attempt < maxAttempts) {
-                const delay = baseDelayMs * 2 ** (attempt - 1) + Math.floor(Math.random() * 100);
+                const delay = jitteredBackoff(baseDelayMs, attempt);
                 console.warn(`OpenAI transient error (attempt ${attempt}/${maxAttempts}). Retrying in ${delay}ms...`);
                 await sleep(delay);
                 continue;
             }
-            // Non-retryable: stop looping
             break;
         }
     }
-    console.error(`Failed after ${maxAttempts} attempts:`, lastError);
-    return null;
-}
-
-// Be tolerant to fenced blocks if upstream prompts ever allow them.
-function extractJson(text: string): string {
-    const fence = /```(?:json)?\s*([\s\S]*?)\s*```/i;
-    const m = fence.exec(text);
-    return m ? m[1] : text.trim();
+    throw new Error(`OpenAI validation failed after ${maxAttempts} attempts. Last error: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
 }
 

--- a/src/openaiValidationUtil.ts
+++ b/src/openaiValidationUtil.ts
@@ -1,0 +1,35 @@
+import type OpenAI from 'openai';
+import { ZodSchema } from 'zod';
+
+/**
+ * Calls OpenAI chat completion API and validates the response with a Zod schema, retrying up to maxAttempts times.
+ * Returns the validated result or null if all attempts fail.
+ */
+export async function callOpenAIWithValidation<T>(
+    openaiClient: OpenAI,
+    chatParams: Parameters<OpenAI['chat']['completions']['create']>[0],
+    zodSchema: ZodSchema<T>,
+    maxAttempts: number = 3
+): Promise<T | null> {
+    let lastError: unknown = null;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            const response = await openaiClient.chat.completions.create(chatParams);
+            // Handle both streaming and non-streaming responses
+            let raw: string | undefined;
+            if ('choices' in response && Array.isArray(response.choices)) {
+                const content = response.choices[0]?.message?.content;
+                raw = typeof content === 'string' ? content : undefined;
+            }
+            if (!raw) throw new Error('No content returned from OpenAI');
+            const parsed = JSON.parse(raw);
+            return zodSchema.parse(parsed);
+        } catch (err) {
+            lastError = err;
+            // Optionally, you can modify chatParams.messages to add feedback for retries
+        }
+    }
+    console.error(`Failed after ${maxAttempts} attempts:`, lastError);
+    return null;
+}
+

--- a/src/openaiValidationUtil.ts
+++ b/src/openaiValidationUtil.ts
@@ -13,15 +13,15 @@ export async function callOpenAIWithValidation<T>(params: {
     userPrompt: string,
     schema: ZodSchema<T>,
     retryCount?: number
-}): Promise<T | null> {
+}): Promise<T> {
     let lastError: unknown = null;
     const baseDelayMs = 500;
     const maxAttempts = params.retryCount ?? 3;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         const messages: ChatCompletionMessageParam[] = [
-            { role: "system", content: params.systemPrompt } as ChatCompletionMessageParam,
-            { role: "user", content: params.userPrompt } as ChatCompletionMessageParam
+            { role: "system", content: params.systemPrompt },
+            { role: "user", content: params.userPrompt }
         ];
 
         // Add feedback about previous failed attempt
@@ -30,7 +30,7 @@ export async function callOpenAIWithValidation<T>(params: {
             messages.push({
                 role: "user",
                 content: `Your previous response was invalid: "${errorMessage}". Please provide only valid JSON with the exact format specified.`
-            } as ChatCompletionMessageParam);
+            });
         }
 
         const chatParams = {


### PR DESCRIPTION


**Description:**  
This PR introduces a reusable utility function, `callOpenAIWithValidation`, which calls the OpenAI client up to a configurable number of times until the response passes a provided Zod validation schema. The function ensures only valid, schema-compliant results are returned, improving data integrity and error handling.

The utility is integrated into both the categorization (`classifyWithOpenAI.ts`) and sentiment analysis (`analyzeSentiment.ts`) modules, replacing custom retry and validation logic. This refactor simplifies code, centralizes validation, and makes future maintenance easier. Type safety is improved by using `unknown` for error handling and explicit message typing for OpenAI requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sample runner demonstrating AI-based post categorization.
  * Introduced a reusable AI response validation utility used across features.

* **Bug Fixes**
  * Improved reliability with strict JSON-only responses, retries, and exponential backoff to reduce malformed outputs and parsing errors.
  * Better handling of rate limits and quota errors.

* **Refactor**
  * Centralized response parsing/validation; sentiment and categorization flows use the unified validation path.

* **Chores**
  * Added simple timing/backoff helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->