### PR TITLE
feat: Add Sentiment-Based Summaries to PostGroup and Store in Redis

### DIFF
--- a/src/generateTitle.ts
+++ b/src/generateTitle.ts
@@ -14,6 +14,20 @@ const TitleSchema = z.object({
     title: z.string().min(5, "Title must be at least 5 characters").max(100, "Title must not exceed 100 characters")
 });
 
+// Sentiment summaries result type
+export type SentimentSummaries = {
+    bullishSummary: string;
+    bearishSummary: string;
+    neutralSummary: string;
+};
+
+// Zod schema for sentiment summaries validation
+const SentimentSummariesSchema = z.object({
+    bullishSummary: z.string().min(10, "Bullish summary must be at least 10 characters").max(500, "Bullish summary must not exceed 500 characters"),
+    bearishSummary: z.string().min(10, "Bearish summary must be at least 10 characters").max(500, "Bearish summary must not exceed 500 characters"),
+    neutralSummary: z.string().min(10, "Neutral summary must be at least 10 characters").max(500, "Neutral summary must not exceed 500 characters")
+});
+
 // Generate title for a single post
 export async function generateTitleForPost(post: string, clientOverride?: OpenAI): Promise<string> {
     const usedClient: OpenAI = clientOverride ?? openai;
@@ -47,6 +61,55 @@ Be strict: return only raw JSON with exactly that shape; no code fences or prose
         return validated.title;
     } catch (e) {
         console.error("Error generating title for post:", post, e);
+        throw e;
+    }
+}
+
+// Generate sentiment-based summaries for a group of posts
+export async function generateSentimentSummariesForGroup(posts: any[], clientOverride?: OpenAI): Promise<SentimentSummaries> {
+    const usedClient: OpenAI = clientOverride ?? openai;
+
+    const systemPrompt = `You are a sentiment analysis and summary generation system for social media posts, particularly crypto and tech-related content.
+
+Instructions:
+1. Analyze the provided posts and their sentiments (BULLISH, BEARISH, NEUTRAL)
+2. Generate three distinct summaries based on sentiment analysis:
+   - bullishSummary: Summarize the key bullish points, optimistic outlook, and positive sentiment from the posts
+   - bearishSummary: Summarize the key bearish points, concerns, and negative sentiment from the posts  
+   - neutralSummary: Summarize the balanced, factual, or neutral observations from the posts
+3. Each summary should be 10-500 characters
+4. Focus on the main themes, key insights, and overall sentiment trends
+5. Make summaries informative and actionable
+6. Return only valid JSON in this format:
+{
+  "bullishSummary": "Your bullish summary here",
+  "bearishSummary": "Your bearish summary here", 
+  "neutralSummary": "Your neutral summary here"
+}
+
+Be strict: return only raw JSON with exactly that shape; no code fences or prose.`;
+
+    const postsJson = JSON.stringify(posts);
+
+    try {
+        const validated = await callOpenAIWithValidation({
+            client: usedClient,
+            systemPrompt,
+            userPrompt: postsJson,
+            schema: SentimentSummariesSchema,
+            retryCount: 3
+        });
+
+        if (!validated?.bullishSummary || !validated?.bearishSummary || !validated?.neutralSummary) {
+            throw new Error(`Sentiment summaries generation failed for posts: ${postsJson}`);
+        }
+        return {
+            bullishSummary: validated.bullishSummary,
+            bearishSummary: validated.bearishSummary,
+            neutralSummary: validated.neutralSummary
+        };
+    } catch (e) {
+        console.error("Error generating sentiment summaries for posts:", postsJson, e);
         throw e;
     }
 }

--- a/src/postGroup.ts
+++ b/src/postGroup.ts
@@ -1,6 +1,6 @@
 
 import cron from 'node-cron';
-import { generateTitleForPost } from './generateTitle';
+import { generateTitleForPost, generateSentimentSummariesForGroup, type SentimentSummaries } from './generateTitle';
 import { initRedis, getRedisClient } from './redisClient';
 
 export type Post = {
@@ -19,12 +19,20 @@ export type PostGroup = {
     id: string;
     posts: Post[];
     title?: string;
+    bullishSummary?: string;
+    bearishSummary?: string;
+    neutralSummary?: string;
 };
 
 // Generate a title for a PostGroup by aggregating its posts' content
 export async function generateTitleForPostGroup(postGroup: PostGroup): Promise<string> {
     const combinedContent = postGroup.posts.map(post => post.content).join('\n\n');
     return await generateTitleForPost(combinedContent);
+}
+
+// Generate sentiment summaries for a PostGroup based on its posts
+export async function generateSentimentSummariesForPostGroup(postGroup: PostGroup): Promise<SentimentSummaries> {
+    return await generateSentimentSummariesForGroup(postGroup.posts);
 }
 
 
@@ -45,7 +53,7 @@ export async function fetchPostGroupsFromRedis(): Promise<PostGroup[]> {
 
 
 
-// Reusable function to generate and log the title for all PostGroups from Redis
+// Reusable function to generate and log the title and sentiment summaries for all PostGroups from Redis
 export async function logTitlesForAllPostGroups(context: 'CRON' | 'MANUAL' = 'MANUAL') {
     const postGroups = await fetchPostGroupsFromRedis();
     if (!postGroups.length) {
@@ -56,11 +64,28 @@ export async function logTitlesForAllPostGroups(context: 'CRON' | 'MANUAL' = 'MA
     const postGroupsWithOrderedKeys = [];
     for (const group of postGroups) {
         let title = group.title;
+        let bullishSummary = group.bullishSummary;
+        let bearishSummary = group.bearishSummary;
+        let neutralSummary = group.neutralSummary;
+
         try {
+            // Generate title
             title = await generateTitleForPostGroup(group);
             if (group.title !== title) {
                 updated = true;
             }
+
+            // Generate sentiment summaries
+            const summaries = await generateSentimentSummariesForPostGroup(group);
+            if (group.bullishSummary !== summaries.bullishSummary ||
+                group.bearishSummary !== summaries.bearishSummary ||
+                group.neutralSummary !== summaries.neutralSummary) {
+                updated = true;
+                bullishSummary = summaries.bullishSummary;
+                bearishSummary = summaries.bearishSummary;
+                neutralSummary = summaries.neutralSummary;
+            }
+
             if (context === 'CRON') {
                 console.log(`[CRON] Generated Title for PostGroup (id: ${group.id}) at ${new Date().toISOString()}:`, title);
             } else {
@@ -68,26 +93,29 @@ export async function logTitlesForAllPostGroups(context: 'CRON' | 'MANUAL' = 'MA
             }
         } catch (e) {
             if (context === 'CRON') {
-                console.error(`[CRON] Error generating title for PostGroup (id: ${group.id}):`, e);
+                console.error(`[CRON] Error generating title/summaries for PostGroup (id: ${group.id}):`, e);
             } else {
-                console.error(`Error generating title for PostGroup (id: ${group.id}):`, e);
+                console.error(`Error generating title/summaries for PostGroup (id: ${group.id}):`, e);
             }
         }
         postGroupsWithOrderedKeys.push({
             id: group.id,
             title,
+            bullishSummary,
+            bearishSummary,
+            neutralSummary,
             posts: group.posts
         });
     }
-    // Save updated PostGroups with titles back to Redis
+    // Save updated PostGroups with titles and summaries back to Redis
     if (updated) {
         await initRedis();
         const redis = getRedisClient();
         await redis.set('post-groups', JSON.stringify(postGroupsWithOrderedKeys));
         if (context === 'CRON') {
-            console.log('[CRON] Updated post-groups with titles saved to Redis.');
+            console.log('[CRON] Updated post-groups with titles and sentiment summaries saved to Redis.');
         } else {
-            console.log('Updated post-groups with titles saved to Redis.');
+            console.log('Updated post-groups with titles and sentiment summaries saved to Redis.');
         }
     }
 }


### PR DESCRIPTION


**Description:**
This PR introduces sentiment-based summaries (bullish, bearish, neutral) for each PostGroup. The following changes are included:
- Added a function to generate sentiment summaries using OpenAI, based on the posts in each group.
- Extended the PostGroup type to include `bullishSummary`, `bearishSummary`, and `neutralSummary` fields.
- Updated the logic to generate and store both the group title and sentiment summaries in Redis.
- Adjusted logging to only print the title, not the summaries, to the terminal.
- All summaries are now generated automatically alongside the title, both in manual and scheduled (cron) runs.